### PR TITLE
Add HasMultipleIneqFields

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -8,7 +8,7 @@ type QueryBuilder struct {
 	Fields     Strings         `json:"fields,omitempty"`
 	Ignored    Strings         `json:"ignored,omitempty"`
 	SortFields Strings         `json:"sort_fields,omitempty"`
-	Conditions []*Condition    `json:"conditions,omitempty"`
+	Conditions Conditions      `json:"conditions,omitempty"`
 	Filters    []*ValuedFilter `json:"filters,omitempty"`
 	Assigns    Assigners       `json:"assigns,omitempty"`
 }
@@ -90,10 +90,7 @@ func (qb *QueryBuilder) ProjectFields() Strings {
 }
 
 func (qb *QueryBuilder) BuildForCount(q *datastore.Query) *datastore.Query {
-	for _, f := range qb.Conditions {
-		q = f.Call(q)
-	}
-	return q
+	return qb.Conditions.Call(q)
 }
 
 func (qb *QueryBuilder) BuildForList(q *datastore.Query) (*datastore.Query, Assigners) {

--- a/conditions.go
+++ b/conditions.go
@@ -1,0 +1,16 @@
+package querybuilder
+
+import (
+	"google.golang.org/appengine/datastore"
+)
+
+type Conditions []*Condition
+
+type ConditionPredict func(*Condition) bool
+
+func (s Conditions) Call(q *datastore.Query) *datastore.Query {
+	for _, i := range s {
+		q = i.Call(q)
+	}
+	return q
+}

--- a/conditions.go
+++ b/conditions.go
@@ -14,3 +14,17 @@ func (s Conditions) Call(q *datastore.Query) *datastore.Query {
 	}
 	return q
 }
+
+func (s Conditions) IneqFields() Strings {
+	r := Strings{}
+	for _, i := range s {
+		if i.Ope != EQ {
+			r = append(r, i.Field)
+		}
+	}
+	return r.Uniq()
+}
+
+func (s Conditions) HasMultipleIneqFields() bool {
+	return len(s.IneqFields()) > 1
+}

--- a/conditions_test.go
+++ b/conditions_test.go
@@ -1,0 +1,32 @@
+package querybuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConditions(t *testing.T) {
+	negatives := []Conditions{
+		Conditions{},
+		Conditions{{"foo", EQ, 1}},
+		Conditions{{"foo", LT, 1}},
+		Conditions{{"foo", LTE, 1}},
+		Conditions{{"foo", GT, 1}},
+		Conditions{{"foo", GTE, 1}},
+		Conditions{{"foo", GTE, 1}, {"foo", LT, 5}},
+		Conditions{{"foo", GTE, 1}, {"bar", EQ, 100}},
+	}
+	for _, c := range negatives {
+		assert.False(t, c.HasMultipleIneqFields())
+	}
+
+	positives := []Conditions{
+		Conditions{{"foo", GTE, 1}, {"foo", LT, 5}, {"bar", GT, 5}},
+		Conditions{{"foo", GTE, 1}, {"bar", GT, 5}},
+	}
+	for _, c := range positives {
+		assert.True(t, c.HasMultipleIneqFields())
+	}
+
+}

--- a/ope.go
+++ b/ope.go
@@ -13,3 +13,14 @@ const (
 func (ope Ope) String() string {
 	return string(ope)
 }
+
+var Operators = []Ope{LT, LTE, GT, GTE, EQ}
+var OperatorMap = BuildOperatorMap(Operators)
+
+func BuildOperatorMap(opes []Ope) map[string]Ope {
+	r := map[string]Ope{}
+	for _, ope := range opes {
+		r[string(ope)] = ope
+	}
+	return r
+}

--- a/ope_test.go
+++ b/ope_test.go
@@ -1,0 +1,30 @@
+package querybuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOpe(t *testing.T) {
+	mapping := map[Ope]string{
+		LT:  "<",
+		LTE: "<=",
+		GT:  ">",
+		GTE: ">=",
+		EQ:  "=",
+	}
+
+	for ope, str := range mapping {
+		assert.Equal(t, str, ope.String())
+		r, ok := OperatorMap[str]
+		assert.True(t, ok)
+		assert.Equal(t, ope, r)
+	}
+
+	invalids := []string{"!=", "<>", "=<", "=>", "=="}
+	for _, invalid := range invalids {
+		_, ok := OperatorMap[invalid]
+		assert.False(t, ok)
+	}
+}

--- a/strings.go
+++ b/strings.go
@@ -12,19 +12,21 @@ func (s Strings) Has(v string) bool {
 }
 
 func (s Strings) Except(v Strings) Strings {
-	r := Strings{}
-	for _, i := range s {
-		if !v.Has(i) {
-			r = append(r, i)
-		}
-	}
-	return r
+	return s.Filter(func(_ Strings, i string) bool {
+		return !v.Has(i)
+	})
 }
 
 func (s Strings) Uniq() Strings {
+	return s.Filter(func(r Strings, i string) bool {
+		return !r.Has(i)
+	})
+}
+
+func (s Strings) Filter(f func(Strings, string) bool) Strings {
 	r := Strings{}
 	for _, i := range s {
-		if !r.Has(i) {
+		if f(r, i) {
 			r = append(r, i)
 		}
 	}

--- a/strings.go
+++ b/strings.go
@@ -20,3 +20,13 @@ func (s Strings) Except(v Strings) Strings {
 	}
 	return r
 }
+
+func (s Strings) Uniq() Strings {
+	r := Strings{}
+	for _, i := range s {
+		if !r.Has(i) {
+			r = append(r, i)
+		}
+	}
+	return r
+}


### PR DESCRIPTION
Add `HasMultipleIneqFields` to detect multiple fields with Inequality filters because `Inequality filters are limited to at most one property` .
See https://cloud.google.com/appengine/docs/standard/go/datastore/query-restrictions for more detail.
